### PR TITLE
build: gradle에 UTF-8 인코딩 추가

### DIFF
--- a/salida/build.gradle.kts
+++ b/salida/build.gradle.kts
@@ -33,6 +33,10 @@ tasks.withType<Test> {
 	useJUnitPlatform()
 }
 
+tasks.withType<JavaCompile>{
+	options.encoding = "UTF-8"
+}
+
 tasks.bootBuildImage {
 	builder.set("paketobuildpacks/builder-jammy-base:latest")
 }


### PR DESCRIPTION
JSON으로 넘겨받는 String의 한글 깨짐 방지를 위한 인코딩